### PR TITLE
ci:自动替换运行库为指定版本

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,9 +1,9 @@
 name: install
 
 # 依赖版本号：留空使用最新版，或指定如 "v4.6.0" / "v0.6.0"
-# env:
-  # MAAFRAMEWORK_VERSION: "v5.5.0"   # MaaXYZ/MaaFramework 版本
-  # MFAAVALONIA_VERSION: "v2.6.0"   # SweetSmellFox/MFAAvalonia 版本
+env:
+  MAAFRAMEWORK_VERSION: ""   # MaaXYZ/MaaFramework 版本
+  MFAAVALONIA_VERSION: ""   # SweetSmellFox/MFAAvalonia 版本
 
 on:
   push:
@@ -124,7 +124,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        os: [win, macos, linux, android]
+        os: [win, macos, linux]
         arch: [aarch64, x86_64]
       fail-fast: false
 
@@ -144,7 +144,6 @@ jobs:
           extract: true
 
       - name: Download MFAAvalonia
-        if: matrix.os != 'android'
         id: download_mfa
         uses: robinraju/release-downloader@v1
         with:
@@ -156,7 +155,6 @@ jobs:
           extract: true
 
       - name: Clean up MFAAvalonia archive
-        if: matrix.os != 'android'
         shell: bash
         run: |
           ARCHIVE_FILE_PATH="${{ fromJson(steps.download_mfa.outputs.downloaded_files)[0] }}"
@@ -193,26 +191,19 @@ jobs:
 
       - name: Install
         shell: bash
-        env:
-          TARGET_OS: ${{ matrix.os }}
         run: |
           python -m pip install json-with-comments
-          python ./tools/install.py ${{ needs.meta.outputs.tag }}
+          python ./tools/install.py ${{ needs.meta.outputs.tag }} ${{ matrix.os }} ${{ matrix.arch }}
 
-          if [[ "${{ matrix.os }}" != "android" ]]; then
-            if [ -d "MFA" ]; then
-              echo "Copying MFA files to install directory..."
-              mkdir -p install
-              rsync -av --ignore-existing MFA/ install/
-            else
-              echo "MFA directory not found, skipping copy."
-            fi
+          if [ -d "MFA" ]; then
+            echo "Copying MFA files to install directory..."
+            mkdir -p install
+            rsync -av --ignore-existing MFA/ install/
           else
-            echo "Skipping copy MFA for Android."
+            echo "MFA directory not found, skipping copy."
           fi
 
       - uses: actions/download-artifact@v4
-        if: matrix.os != 'android'
         with:
           name: python-embed-${{ matrix.os }}-${{ matrix.arch }}
           path: ./install/python

--- a/tools/install.py
+++ b/tools/install.py
@@ -1,17 +1,58 @@
 from pathlib import Path
 
-import os
 import shutil
 import sys
 import json
 import jsonc
-
+import platform
 from configure import configure_ocr_model
 
 
 working_dir = Path(__file__).parent.parent
 install_path = working_dir / Path("install")
 version = len(sys.argv) > 1 and sys.argv[1] or "v0.0.1"
+
+
+def _raw_os_and_arch() -> tuple[str, str]:
+    """CI: argv 为 tag, os, arch；本地未传 os/arch 时用 platform 推断。"""
+    if len(sys.argv) >= 4:
+        return sys.argv[2].strip(), sys.argv[3].strip()
+    sys_map = {"windows": "win", "linux": "linux", "darwin": "osx"}
+    raw_os = sys_map.get(platform.system().lower(), platform.system().lower())
+    return raw_os, platform.machine().lower()
+
+
+def normalize_os(raw: str) -> str:
+    """规范为 win / linux / osx；CI 的 android 单独保留。"""
+    s = raw.lower().strip()
+    if s in ("windows", "win32", "win64", "win"):
+        return "win"
+    if s == "linux":
+        return "linux"
+    if s in ("darwin", "macos", "osx", "mac"):
+        return "osx"
+    if s == "android":
+        return "android"
+    print(f"Unsupported OS: {raw!r}")
+    sys.exit(1)
+
+
+def normalize_arch(raw: str) -> str:
+    """规范为 x64 / arm64。"""
+    s = raw.lower().strip()
+    if s in ("amd64", "x86_64", "x64", "x86-64"):
+        return "x64"
+    if s in ("arm64", "aarch64", "armv8", "armv8-a"):
+        return "arm64"
+    print(f"Unsupported architecture: {raw!r}")
+    sys.exit(1)
+
+
+_raw_os, _raw_arch = _raw_os_and_arch()
+# 当前系统（win / linux / osx，CI 上可能为 android）
+current_system = normalize_os(_raw_os)
+# 当前架构（x64 / arm64）
+current_architecture = normalize_arch(_raw_arch)
 
 
 def install_deps():
@@ -22,7 +63,7 @@ def install_deps():
 
     shutil.copytree(
         working_dir / "deps" / "bin",
-        install_path,
+        install_path / "runtimes" / f"{current_system}-{current_architecture}",
         ignore=shutil.ignore_patterns(
             "*MaaDbgControlUnit*",
             "*MaaThriftControlUnit*",
@@ -33,7 +74,7 @@ def install_deps():
     )
     shutil.copytree(
         working_dir / "deps" / "share" / "MaaAgentBinary",
-        install_path / "MaaAgentBinary",
+        install_path / "runtimes" / f"{current_system}-{current_architecture}" / "MaaAgentBinary",
         dirs_exist_ok=True,
     )
 
@@ -80,17 +121,14 @@ def install_agent():
     with open(install_path / "interface.json", "r", encoding="utf-8") as f:
         interface = jsonc.load(f)
 
-    # 根据 CI 传入的 OS 环境变量来设置 child_exec
-    target_os = os.getenv("TARGET_OS", "").lower()
-
-    # OS 到 child_exec 的映射
+    # OS 到 child_exec 的映射（与 normalize_os 的 win / linux / osx 一致）
     os_exec_map = {
         "win": r"./python/python.exe",
-        "macos": r"./python/bin/python3",
+        "osx": r"./python/bin/python3",
         "linux": r"python3",
     }
 
-    match target_os:
+    match current_system:
         case "android":
             # Android 不使用嵌入式 Python
             interface.pop("agent", None)
@@ -99,7 +137,7 @@ def install_agent():
             interface["agent"]["child_args"] = ["-u", r"./agent/main.py"]
             interface["agent"]["embedded"] = True
         case _:
-            raise ValueError(f"Unknown OS: {target_os}")
+            raise ValueError(f"Unknown OS: {current_system}")
 
     with open(install_path / "interface.json", "w", encoding="utf-8") as f:
         json.dump(interface, f, ensure_ascii=False, indent=4)


### PR DESCRIPTION
## Summary by Sourcery

Adjust runtime installation layout to be OS/architecture-specific and align CI with the new install script interface.

New Features:
- Organize installed runtimes under per-platform directories keyed by normalized OS and architecture.

Enhancements:
- Infer and normalize OS/architecture within the install script for both local use and CI, unifying platform handling.
- Update agent configuration selection to use normalized OS identifiers consistent across environments.

CI:
- Set default MaaFramework and MFAAvalonia versions via workflow environment variables.
- Update the install workflow matrix to drop Android builds and pass OS/architecture explicitly to the install script.
- Simplify MFA copy and Python embed artifact download steps now that Android-specific conditionals are removed.