### PR TITLE
Revert "ci: 替换ui"

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,9 +1,9 @@
 name: install
 
-# 依赖版本号：留空使用最新版，或指定如 "v4.6.0"
+# 依赖版本号：留空使用最新版，或指定如 "v4.6.0" / "v0.6.0"
 env:
-  MFWCFA_VERSION: ""   # overflow65537/MFW-PyQt6 版本
-  MAAFRAMEWORK_VERSION: ""   # MaaXYZ/MaaFramework 版本（install.py 需要 bin + share/MaaAgentBinary）
+  MAAFRAMEWORK_VERSION: ""   # MaaXYZ/MaaFramework 版本
+  MFAAVALONIA_VERSION: ""   # SweetSmellFox/MFAAvalonia 版本
 
 on:
   push:
@@ -133,9 +133,7 @@ jobs:
         with:
           submodules: true
 
-      # install.py 从 deps / MFWCFA / 根目录查找 MaaFramework（bin + share/MaaAgentBinary）；MFWCFA 包体不含该布局，需单独拉取运行时。
       - name: Download MaaFramework
-        id: download_maafw
         uses: robinraju/release-downloader@v1
         with:
           repository: MaaXYZ/MaaFramework
@@ -145,83 +143,51 @@ jobs:
           out-file-path: "deps"
           extract: true
 
-      - name: Clean up MaaFramework archive
-        shell: bash
-        run: |
-          ARCHIVE_FILE_PATH="${{ fromJson(steps.download_maafw.outputs.downloaded_files)[0] }}"
-          rm -f "${ARCHIVE_FILE_PATH}"
-          echo "Archive cleanup command executed for MaaFramework."
-
-      - name: Normalize MaaFramework layout under deps
-        shell: bash
-        run: |
-          if [[ -d deps/bin && -d deps/share/MaaAgentBinary ]]; then
-            echo "MaaFramework already at deps root."
-            exit 0
-          fi
-          for d in deps/*/; do
-            [[ -d "${d}bin" && -d "${d}share/MaaAgentBinary" ]] || continue
-            echo "Lifting MaaFramework from $d to deps/"
-            mv "${d}bin" deps/
-            mv "${d}share" deps/
-            rm -rf "$d"
-            exit 0
-          done
-          echo "❌ Could not find bin + share/MaaAgentBinary under deps/"
-          find deps -maxdepth 4 -type d 2>/dev/null || true
-          exit 1
-
-      - name: Download MFWCFA
-        id: download_mfwcfa
+      - name: Download MFAAvalonia
+        id: download_mfa
         uses: robinraju/release-downloader@v1
         with:
-          repository: overflow65537/MFW-PyQt6
-          fileName: "MFW*-${{ matrix.os }}-${{ matrix.arch }}*"
-          tag: ${{ env.MFWCFA_VERSION }}
-          latest: ${{ env.MFWCFA_VERSION == '' }}
-          out-file-path: "MFWCFA"
+          repository: SweetSmellFox/MFAAvalonia
+          fileName: "MFAAvalonia-*-${{ (matrix.os == 'win' && 'win') || (matrix.os == 'macos' && 'osx') || (matrix.os == 'linux' && 'linux') }}-${{ (matrix.arch == 'x86_64' && 'x64') || (matrix.arch == 'aarch64' && 'arm64') }}*"
+          tag: ${{ env.MFAAVALONIA_VERSION }}
+          latest: ${{ env.MFAAVALONIA_VERSION == '' }}
+          out-file-path: "MFA"
           extract: true
 
-      - name: Clean up MFWCFA archive
+      - name: Clean up MFAAvalonia archive
         shell: bash
         run: |
-          ARCHIVE_FILE_PATH="${{ fromJson(steps.download_mfwcfa.outputs.downloaded_files)[0] }}"
+          ARCHIVE_FILE_PATH="${{ fromJson(steps.download_mfa.outputs.downloaded_files)[0] }}"
           rm -f "${ARCHIVE_FILE_PATH}"
-          echo "Archive cleanup command executed for MFWCFA."
+          echo "Archive cleanup command executed for MFAAvalonia."
 
-#      - name: Apply custom icon to MFW.exe on Windows
-#        if: matrix.os == 'win'
-#        shell: bash
-#        run: |
-#          ICON_PATH="./assets/resource/base/image/logo.ico"
-#          if [ ! -f "$ICON_PATH" ]; then
-#            echo "❌ ERROR: Icon file not found at $ICON_PATH"
-#            exit 1
-#          fi
-#
-#          MFW_EXE="$(find MFWCFA -maxdepth 2 -type f -name 'MFW.exe' | head -n 1)"
-#          if [ -z "$MFW_EXE" ]; then
-#            echo "❌ ERROR: MFW.exe not found under MFWCFA"
-#            exit 1
-#          fi
-#
-#          echo "✅ Applying icon from $ICON_PATH to $MFW_EXE..."
-#
-#          # Download rcedit.exe (Windows tool)
-#          curl -L https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe -o rcedit.exe
-#
-#          # Install wine if not present
-#          if ! command -v wine &> /dev/null; then
-#            echo "📦 Installing wine..."
-#            sudo apt-get update
-#            sudo apt-get install -y wine
-#          fi
-#
-#          # Make it executable and run via wine
-#          chmod +x rcedit.exe
-#          wine ./rcedit.exe "$MFW_EXE" --set-icon "$ICON_PATH"
-#
-#          echo "✅ Icon successfully applied."
+      - name: Apply custom icon to MFAAvalonia.exe on Windows
+        if: matrix.os == 'win'
+        shell: bash
+        run: |
+          ICON_PATH="./assets/resource/base/image/logo.ico"
+          if [ ! -f "$ICON_PATH" ]; then
+            echo "❌ ERROR: Icon file not found at $ICON_PATH"
+            exit 1
+          fi
+
+          echo "✅ Applying icon from $ICON_PATH to MFA/MFAAvalonia.exe..."
+
+          # Download rcedit.exe (Windows tool)
+          curl -L https://github.com/electron/rcedit/releases/download/v2.0.0/rcedit-x64.exe -o rcedit.exe
+
+          # Install wine if not present
+          if ! command -v wine &> /dev/null; then
+            echo "📦 Installing wine..."
+            sudo apt-get update
+            sudo apt-get install -y wine
+          fi
+
+          # Make it executable and run via wine
+          chmod +x rcedit.exe
+          wine ./rcedit.exe "MFA/MFAAvalonia.exe" --set-icon "$ICON_PATH"
+
+          echo "✅ Icon successfully applied."
 
       - name: Install
         shell: bash
@@ -229,12 +195,12 @@ jobs:
           python -m pip install json-with-comments
           python ./tools/install.py ${{ needs.meta.outputs.tag }} ${{ matrix.os }} ${{ matrix.arch }}
 
-          if [ -d "MFWCFA" ]; then
-            echo "Copying MFWCFA files to install directory..."
+          if [ -d "MFA" ]; then
+            echo "Copying MFA files to install directory..."
             mkdir -p install
-            rsync -av --ignore-existing MFWCFA/ install/
+            rsync -av --ignore-existing MFA/ install/
           else
-            echo "MFWCFA directory not found, skipping copy."
+            echo "MFA directory not found, skipping copy."
           fi
 
       - uses: actions/download-artifact@v4

--- a/tools/install.py
+++ b/tools/install.py
@@ -54,31 +54,14 @@ current_system = normalize_os(_raw_os)
 current_architecture = normalize_arch(_raw_arch)
 
 
-def _framework_root_candidates() -> list[Path]:
-    return [
-        working_dir / "deps",
-        working_dir / "MFWCFA",
-        working_dir,
-    ]
-
-
-def _find_framework_root() -> Path:
-    for candidate in _framework_root_candidates():
-        if (candidate / "bin").exists() and (
-            candidate / "share" / "MaaAgentBinary"
-        ).exists():
-            return candidate
-
-    print('Please prepare MaaFramework files under "deps", "MFWCFA", or project root.')
-    print('请先将 MaaFramework 文件放到 "deps"、"MFWCFA" 或项目根目录。')
-    sys.exit(1)
-
-
 def install_deps():
-    framework_root = _find_framework_root()
+    if not (working_dir / "deps" / "bin").exists():
+        print('Please download the MaaFramework to "deps" first.')
+        print('请先下载 MaaFramework 到 "deps"。')
+        sys.exit(1)
 
     shutil.copytree(
-        framework_root / "bin",
+        working_dir / "deps" / "bin",
         install_path / "runtimes" / f"{current_system}-{current_architecture}",
         ignore=shutil.ignore_patterns(
             "*MaaDbgControlUnit*",
@@ -89,7 +72,7 @@ def install_deps():
         dirs_exist_ok=True,
     )
     shutil.copytree(
-        framework_root / "share" / "MaaAgentBinary",
+        working_dir / "deps" / "share" / "MaaAgentBinary",
         install_path
         / "runtimes"
         / f"{current_system}-{current_architecture}"
@@ -140,7 +123,7 @@ def install_chores():
             install_path / file,
         )
 
- # 与 logo 相同，供 MFW 等使用（须在上述 logo.png 复制完成之后）
+        # 复制logo图片
     shutil.copy2(
         install_path / "logo.png",
         install_path / "dashboard.png",


### PR DESCRIPTION
Reverts miaojiuqing/Maa_bbb#69

## Summary by Sourcery

将 CI 安装工作流和安装脚本切换回在 `deps` 中使用 MaaFramework，以及使用 MFAAvalonia UI bundle，移除对旧的 MFWCFA 布局的支持。

增强：
- 简化安装脚本，假定 MaaFramework 提供在 `deps/bin` 和 `deps/share/MaaAgentBinary` 下，而不是探测多个可能的位置。

构建：
- 更新安装工作流，将 MaaFramework 下载到 `deps` 中，并获取 MFAAvalonia 构建产物以替代 MFWCFA，包括对 Windows 图标应用以及构建产物复制方式的调整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Switch CI install workflow and installer script back to using MaaFramework in deps and the MFAAvalonia UI bundle, removing support for the previous MFWCFA layout.

Enhancements:
- Simplify install script to assume MaaFramework is provided under deps/bin and deps/share/MaaAgentBinary instead of probing multiple possible locations.

Build:
- Update install workflow to download MaaFramework into deps and fetch MFAAvalonia artifacts instead of MFWCFA, including Windows icon application and artifact copying adjustments.

</details>